### PR TITLE
Revert "Bump jsmrcaga/action-netlify-deploy from 1.7.0 to 1.7.1"

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build examples
         run: |
           ./.github/scripts/build_examples.sh
-      - uses: jsmrcaga/action-netlify-deploy@v1.7.1
+      - uses: jsmrcaga/action-netlify-deploy@v1.7.0
         if: ${{ github.event_name != 'schedule' }}
         with:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
Reverts tommket/seed-datepicker#18

Reverting the jsmrcaga/action-netlify-deploy from 1.7.1 to 1.7.0, because the deployment of examples failed.